### PR TITLE
Support stats retrieval from a network namespace

### DIFF
--- a/jool_exporter.py
+++ b/jool_exporter.py
@@ -30,9 +30,7 @@ class JoolCollector:
     label_values = [HOSTNAME]
     namespace = None
 
-    def __init__(
-        self, namespace: str = None
-    ):
+    def __init__(self, namespace: str = None):
         if namespace:
             self.namespace = namespace
             self.labels.append("namespace")

--- a/jool_exporter_tests.py
+++ b/jool_exporter_tests.py
@@ -17,7 +17,7 @@ jool_exporter.LOG = Mock()
 class TestJoolExporter(unittest.TestCase):
     def setUp(self) -> None:
         self.je = jool_exporter.JoolCollector()
-        self.je_ns = jool_exporter.JoolCollector('some_namespace')
+        self.je_ns = jool_exporter.JoolCollector("some_namespace")
 
     def test_handle_debug(self) -> None:
         self.assertFalse(jool_exporter._handle_debug(False))

--- a/jool_exporter_tests.py
+++ b/jool_exporter_tests.py
@@ -17,6 +17,7 @@ jool_exporter.LOG = Mock()
 class TestJoolExporter(unittest.TestCase):
     def setUp(self) -> None:
         self.je = jool_exporter.JoolCollector()
+        self.je_ns = jool_exporter.JoolCollector('some_namespace')
 
     def test_handle_debug(self) -> None:
         self.assertFalse(jool_exporter._handle_debug(False))


### PR DESCRIPTION
This change enables the exporter to run in the default network namespace and retrieve the statistics from Jool running in an isolated namespace.

Introduces a new argument, `-n` (`--namespace`), followed by the name of the namespace.