### PR TITLE
Add --addr argument

### DIFF
--- a/jool_exporter.py
+++ b/jool_exporter.py
@@ -94,7 +94,7 @@ def main() -> int:
     parser.add_argument(
         "-a",
         "--addr",
-        default="0.0.0.0",
+        default=DEFAULT_ADDR,
         help=f"Address to bind socket to [Default = {DEFAULT_ADDR}]",
     )
     parser.add_argument(

--- a/jool_exporter.py
+++ b/jool_exporter.py
@@ -19,6 +19,7 @@ from prometheus_client.core import GaugeMetricFamily, REGISTRY
 from prometheus_client.registry import Collector
 
 
+DEFAULT_ADDR = "0.0.0.0"
 DEFAULT_PORT = 6971
 HOSTNAME = getfqdn()
 LOG = logging.getLogger(__name__)
@@ -91,6 +92,12 @@ def main() -> int:
         description="Export `jool stats display` for prometheus"
     )
     parser.add_argument(
+        "-a",
+        "--addr",
+        default="0.0.0.0",
+        help=f"Address to bind socket to [Default = {DEFAULT_ADDR}]",
+    )
+    parser.add_argument(
         "-d", "--debug", action="store_true", help="Verbose debug output"
     )
     parser.add_argument(
@@ -104,7 +111,7 @@ def main() -> int:
     _handle_debug(args.debug)
 
     LOG.info(f"Starting {sys.argv[0]}")
-    start_http_server(args.port)
+    start_http_server(args.port, args.addr)
     REGISTRY.register(JoolCollector())
     LOG.info(f"jool prometheus exporter - listening on {args.port}")
     try:


### PR DESCRIPTION
- Allow people to specify different addresses to bind http server socker to
  - e.g. IPv6

Test:
- Start locally on IPv6
```
cooper@home1:~/repos/jool-exporter$ python3 -m venv --upgrade-deps /tmp/tj
cooper@home1:~/repos/jool-exporter$ /tmp/tj/bin/pip install -e .
cooper@home1:~/repos/jool-exporter$ /tmp/tj/bin/jool-exporter -p 1234 -a ::
[2025-03-08 17:01:30,664] INFO: Starting /tmp/tj/bin/jool-exporter (jool_exporter.py:112)
[2025-03-08 17:01:30,665] INFO: Collection started (jool_exporter.py:42)
[2025-03-08 17:01:30,667] INFO: Collection finished in 0.002140045166015625s (jool_exporter.py:62)
[2025-03-08 17:01:30,667] INFO: jool prometheus exporter - listening on 1234 (jool_exporter.py:115

cooper@home1:~$ sudo netstat -tapn | grep '1234 '
tcp6       0      0 :::1234                 :::*                    LISTEN      3368015/python3

cooper@home1:~/repos/jool-exporter$ curl http://[::]:1234/metrics
... See metrics ...
```

Fixes #4 