### PR TITLE
Ensure instance is correctly parsed

### DIFF
--- a/jool_exporter.py
+++ b/jool_exporter.py
@@ -70,7 +70,7 @@ class JoolCollector(Collector):
     def run_jool(self) -> Union[str, CompletedProcess]:
         cmd = [
             self.args.cli,
-            f"-i {self.args.instance}",
+            f"--instance={self.args.instance}",
             "stats",
             "display",
             "--csv",


### PR DESCRIPTION
With the previous flag, the instance was detected with a space in front. This change should solve that.